### PR TITLE
Fix Driver provider-configuration file

### DIFF
--- a/jdbc42/src/main/java/dev/jfr4jdbc/Jfr4JdbcDriver.java
+++ b/jdbc42/src/main/java/dev/jfr4jdbc/Jfr4JdbcDriver.java
@@ -59,13 +59,18 @@ public class Jfr4JdbcDriver implements Driver {
 
         // Checking whether the driver is present.
         String delegeteJdbcDriverUrl = Jfr4JdbcDriver.getDelegateUrl(url);
-        Driver delegateDriver = (this.delegateJdbcDriver == null) ? DriverManager.getDriver(delegeteJdbcDriverUrl) : this.delegateJdbcDriver;
-
-        if (delegateDriver == null) {
-            return false;
+        Driver delegateDriver;
+        if (this.delegateJdbcDriver == null) {
+            try {
+                delegateDriver = DriverManager.getDriver(delegeteJdbcDriverUrl);
+            } catch (SQLException e) {
+                delegateDriver = null;
+            }
+        } else {
+            delegateDriver = this.delegateJdbcDriver;
         }
 
-        return true;
+        return delegateDriver != null;
     }
 
     @Override

--- a/jdbc42/src/main/resources/META-INF/services/java.sql.Driver
+++ b/jdbc42/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+dev.jfr4jdbc.Jfr4JdbcDriver

--- a/jdbc42/src/main/resources/services/java.sql.Driver
+++ b/jdbc42/src/main/resources/services/java.sql.Driver
@@ -1,1 +1,0 @@
-Jfr4JdbcDriver

--- a/jdbc42/src/test/java/dev/jfr4jdbc/Jfr4JdbcDriverTest.java
+++ b/jdbc42/src/test/java/dev/jfr4jdbc/Jfr4JdbcDriverTest.java
@@ -157,11 +157,8 @@ class Jfr4JdbcDriverTest {
     @DisplayName("notGetConnection")
     @Test
     void notGetConnection() {
-        try {
-            DriverManager.getDriver(NOT_FOUND_URL);
-            fail();
-        } catch (SQLException e) {
-        }
+        assertThrows(SQLException.class, () -> DriverManager.getDriver("jdbc:yyy"));
+        assertThrows(SQLException.class, () -> DriverManager.getDriver(NOT_FOUND_URL));
     }
 
 


### PR DESCRIPTION
The contents of the file must contain the full path to the name of the Driver.

Additionally, the file must be in META-INF/services to be found.