### PR TITLE
Make the base event abstract to avoid logging it

### DIFF
--- a/jdbc42/src/main/java/dev/jfr4jdbc/event/jfr/JfrJdbcEvent.java
+++ b/jdbc42/src/main/java/dev/jfr4jdbc/event/jfr/JfrJdbcEvent.java
@@ -5,5 +5,5 @@ import jdk.jfr.Category;
 import jdk.jfr.Event;
 
 @Category("jdbc")
-public class JfrJdbcEvent extends Event implements JdbcEvent {
+public abstract class JfrJdbcEvent extends Event implements JdbcEvent {
 }


### PR DESCRIPTION
If not abstract it shows up in JFR even though it doesn't get used for anything.