### PR TITLE
Add events for JDBC Savepoints

### DIFF
--- a/jdbc42/src/main/java/dev/jfr4jdbc/EventFactory.java
+++ b/jdbc42/src/main/java/dev/jfr4jdbc/EventFactory.java
@@ -24,6 +24,11 @@ public abstract class EventFactory {
     public abstract ResultSetEvent createResultSetEvent();
 
     public abstract RollbackEvent createRollbackEvent();
+
+    /**
+     * @param action One of: {@code create}, {@code rollback}, or {@code release}.
+     */
+    public abstract SavepointEvent createSavepointEvent(String action);
 }
 
 class JfrEventFactory extends EventFactory {
@@ -61,5 +66,10 @@ class JfrEventFactory extends EventFactory {
     @Override
     public RollbackEvent createRollbackEvent() {
         return new JfrRollbackEvent();
+    }
+
+    @Override
+    public SavepointEvent createSavepointEvent(String action) {
+        return new JfrSavepointEvent(action);
     }
 }

--- a/jdbc42/src/main/java/dev/jfr4jdbc/event/SavepointEvent.java
+++ b/jdbc42/src/main/java/dev/jfr4jdbc/event/SavepointEvent.java
@@ -1,0 +1,7 @@
+package dev.jfr4jdbc.event;
+
+public interface SavepointEvent extends JdbcEvent {
+		void setId(int id);
+
+		void setName(String name);
+}

--- a/jdbc42/src/main/java/dev/jfr4jdbc/event/jfr/JfrSavepointEvent.java
+++ b/jdbc42/src/main/java/dev/jfr4jdbc/event/jfr/JfrSavepointEvent.java
@@ -1,0 +1,34 @@
+package dev.jfr4jdbc.event.jfr;
+
+import dev.jfr4jdbc.event.SavepointEvent;
+import jdk.jfr.Label;
+
+@Label("Savepoint")
+public final class JfrSavepointEvent extends JfrJdbcEvent implements SavepointEvent {
+
+    @Label("Id")
+    private int id;
+
+    @Label("Name")
+    private String name;
+
+    /**
+     * One of: {@code create}, {@code rollback}, or {@code release}.
+     */
+    @Label("Action")
+    private final String action;
+
+    public JfrSavepointEvent(String action) {
+        this.action = action;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/jdbc42/src/main/java/dev/jfr4jdbc/internal/JfrSavepoint.java
+++ b/jdbc42/src/main/java/dev/jfr4jdbc/internal/JfrSavepoint.java
@@ -1,0 +1,25 @@
+package dev.jfr4jdbc.internal;
+
+import java.sql.SQLException;
+import java.sql.Savepoint;
+import java.util.Objects;
+
+final class JfrSavepoint implements Savepoint {
+	  final Savepoint jdbcSavepoint;
+	  final boolean isNamed;
+
+		JfrSavepoint(Savepoint jdbcSavepoint, boolean isNamed) {
+		    this.jdbcSavepoint = Objects.requireNonNull(jdbcSavepoint);
+			  this.isNamed = isNamed;
+		}
+
+	  @Override
+	  public int getSavepointId() throws SQLException {
+	    	return jdbcSavepoint.getSavepointId();
+	  }
+
+	  @Override
+	  public String getSavepointName() throws SQLException {
+	    	return jdbcSavepoint.getSavepointName();
+	  }
+}

--- a/jdbc42/src/test/java/dev/jfr4jdbc/FlightRecording.java
+++ b/jdbc42/src/test/java/dev/jfr4jdbc/FlightRecording.java
@@ -34,6 +34,7 @@ public class FlightRecording {
             fr.recording.enable(JfrConnectionEvent.class);
             fr.recording.enable(JfrResultSetEvent.class);
             fr.recording.enable(JfrRollbackEvent.class);
+            fr.recording.enable(JfrSavepointEvent.class);
             fr.recording.enable(JfrStatementEvent.class);
             fr.recording.disable(JfrConnectionResourceEvent.class);
             fr.recording.start();
@@ -56,6 +57,7 @@ public class FlightRecording {
             recording.disable(JfrConnectionEvent.class);
             recording.disable(JfrResultSetEvent.class);
             recording.disable(JfrRollbackEvent.class);
+            recording.disable(JfrSavepointEvent.class);
             recording.disable(JfrStatementEvent.class);
             recording.dump(this.dumpFilePath);
             recording.stop();


### PR DESCRIPTION
Create events when savepoints are created, rolled back, and released. Savepoints have either a name or ID, so log those in all cases.